### PR TITLE
Clarify what is actually powering Wikipedia and Snagajob

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a fork of https://github.com/o19s/elasticsearch-learning-to-rank to work with OpenSearch. It's a rewrite of some parts to be able to work with OpenSearch 1.x. Please refer to official documentation of [Elasticsearch Learning to Rank](http://elasticsearch-learning-to-rank.readthedocs.io) for usage.
 
-The OpenSearch Learning to Rank plugin uses machine learning to improve search relevance ranking. It's powering search at places like Wikimedia Foundation and Snagajob!
+The OpenSearch Learning to Rank plugin uses machine learning to improve search relevance ranking. The original Elasticsearch LTR plugin is powering search at places like Wikimedia Foundation and Snagajob!
 
 
 # Installing


### PR DESCRIPTION
Wanted to clarify that it's the original plugin, not the OpenSearch fork, that is being used at Wikipedia and Snagajob - those organisations collaborated with OSC on the development, so this is important.